### PR TITLE
Added intent filter for TWEET_BROADCAST, Setup Tweet Broadcasting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,11 @@
 
         <activity
             android:name=".TweetFeedActivity"
-            android:label="@string/title_activity_main"></activity>
+            android:label="@string/title_activity_main">
+            <intent-filter>
+                <action android:name="@string/tweet_broadcast" />
+            </intent-filter>
+        </activity>
         <activity android:name=".SearchActivity" />
 
         <!--

--- a/app/src/main/java/com/dankideacentral/dic/BaseMapActivity.java
+++ b/app/src/main/java/com/dankideacentral/dic/BaseMapActivity.java
@@ -1,5 +1,6 @@
 package com.dankideacentral.dic;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.location.LocationManager;
 import android.support.v4.app.FragmentActivity;

--- a/app/src/main/java/com/dankideacentral/dic/TweetFeedActivity.java
+++ b/app/src/main/java/com/dankideacentral/dic/TweetFeedActivity.java
@@ -1,9 +1,11 @@
 package com.dankideacentral.dic;
 
 import android.Manifest;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.location.Location;
 import android.location.LocationListener;
@@ -14,6 +16,7 @@ import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -32,6 +35,8 @@ import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.clustering.ClusterManager;
 
 import java.util.Arrays;
+
+import twitter4j.Status;
 
 public class TweetFeedActivity extends BaseMapActivity
         implements OnListFragmentInteractionListener, ClusterManager.OnClusterClickListener, ClusterManager.OnClusterItemClickListener, LocationListener {
@@ -52,7 +57,6 @@ public class TweetFeedActivity extends BaseMapActivity
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         setContentView(R.layout.activity_tweet_feed);
         fm = new Fragmenter(getSupportFragmentManager());
 
@@ -89,6 +93,17 @@ public class TweetFeedActivity extends BaseMapActivity
         startIntent.putExtra(getString(R.string.intent_long), log);
         startService(startIntent);
         bindService(bindIntent, mConnection, Context.BIND_AUTO_CREATE);
+
+        // set up broadcast reciever
+        LocalBroadcastManager.getInstance(this).registerReceiver(new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                Status tweet = (Status) intent.getExtras().get("tweet");
+                Log.v("Received Tweet: ", tweet.toString());
+                clusterManager.addItem(new TweetNode(tweet.getGeoLocation()));
+                clusterManager.cluster();
+            }
+        }, new IntentFilter(getString(R.string.tweet_broadcast)));
     }
 
     @Override

--- a/app/src/main/java/com/dankideacentral/dic/TwitterStreamService.java
+++ b/app/src/main/java/com/dankideacentral/dic/TwitterStreamService.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.os.Binder;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import twitter4j.conf.ConfigurationBuilder;
 public class TwitterStreamService extends Service {
 
     private final IBinder mBinder = new TwitterStreamBinder();
+
     private TwitterStream twitterStream = null;
     private GeolocationFilter geoFilter = null;
     private HashMap<GeoLocation, Integer> locationCount = new HashMap<GeoLocation, Integer>();
@@ -79,9 +81,14 @@ public class TwitterStreamService extends Service {
         public void onStatus(Status status) {
             GeoLocation tweetLocation = status.getGeoLocation();
             Log.d("TwitterStream - tweet", tweetLocation.toString());
+
             if (tweetLocation != null && geoFilter.inSearchRegion(tweetLocation)) {
                 addToLocationCount(tweetLocation);
-                Log.d("TwitterStream - tweet", tweetLocation.toString());
+
+                Intent statusIntent = new Intent(getApplicationContext(), TweetFeedActivity.class);
+                statusIntent.setAction(getString(R.string.tweet_broadcast));
+                statusIntent.putExtra("tweet", status);
+                LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(statusIntent);
             }
         }
 

--- a/app/src/main/java/com/dankideacentral/dic/model/TweetNode.java
+++ b/app/src/main/java/com/dankideacentral/dic/model/TweetNode.java
@@ -3,12 +3,20 @@ package com.dankideacentral.dic.model;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.ClusterItem;
 
+import twitter4j.GeoLocation;
+
 
 public class TweetNode implements ClusterItem {
-    LatLng position;
+    private LatLng position;
+
     public TweetNode (double lat, double lng) {
         position = new LatLng(lat, lng);
     }
+
+    public TweetNode (GeoLocation geo) {
+        this.position = new LatLng(geo.getLatitude(), geo.getLongitude());
+    }
+
     public TweetNode (LatLng coords) {
         this.position = coords;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,5 +41,5 @@
     <!-- TwitterStreamService Intent Strings -->
     <string name = "intent_lat" translatable="false">latitude</string>
     <string name = "intent_long" translatable="false">longitude</string>
-
+    <string name = "tweet_broadcast" translatable="false">com.dankideacentral.dic.TWEET_BROADCAST</string>
 </resources>


### PR DESCRIPTION
Let me know what you think, just put this out there to get us started on broadcasting from the service.

The broadcast receiver in `TweetFeedActivity` will only create a cluster when a tweet is found in your area (currently hardcoded as Ottawa from @zandermax's commit).

No task is currently up for this, just figured it would be useful to have moving forward.
