### PR TITLE
Add event notification on cluster

### DIFF
--- a/app/src/main/java/com/dankideacentral/dic/activities/BaseMapActivity.java
+++ b/app/src/main/java/com/dankideacentral/dic/activities/BaseMapActivity.java
@@ -2,11 +2,13 @@ package com.dankideacentral.dic.activities;
 
 import android.content.Context;
 import android.location.LocationManager;
+import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 import com.dankideacentral.dic.algo.WeightedNodeAlgorithm;
 import com.dankideacentral.dic.model.TweetNode;
+import com.dankideacentral.dic.util.NotificationHandler;
 import com.dankideacentral.dic.view.WeightedNodeRenderer;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -16,15 +18,25 @@ import com.google.maps.android.clustering.ClusterManager;
 /**
  * Created by srowhani on 10/6/16.
  */
-
 public abstract class BaseMapActivity extends AppCompatActivity implements
         OnMapReadyCallback, ClusterManager.OnClusterClickListener, ClusterManager.OnClusterItemClickListener {
+
+    private static final int EVENT_NOTIFICATION_ID = -1;
+
+    protected NotificationHandler notificationHandler;
+
     private GoogleMap mMap;
     private SupportMapFragment mapFragment;
 
     private ClusterManager <TweetNode> mClusterManager;
     private WeightedNodeAlgorithm <TweetNode> mNodeAlgorithm;
     private WeightedNodeRenderer <TweetNode> mNodeRenderer;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState){
+        super.onCreate(savedInstanceState);
+        notificationHandler = new NotificationHandler(this, TweetFeedActivity.class);
+    }
 
     public BaseMapActivity () {
         mapFragment = SupportMapFragment.newInstance();
@@ -49,7 +61,14 @@ public abstract class BaseMapActivity extends AppCompatActivity implements
 
         mClusterManager = new ClusterManager(this, mMap);
         mNodeAlgorithm = new WeightedNodeAlgorithm <TweetNode>();
-        mNodeRenderer = new WeightedNodeRenderer<TweetNode>(this, mMap, mClusterManager);
+
+        mNodeRenderer = new WeightedNodeRenderer<TweetNode>(this, mMap, mClusterManager) {
+            @Override
+            public void sendUserNotification() {
+                notificationHandler.sendNotification("An event is occurring near you!",
+                        EVENT_NOTIFICATION_ID);
+            }
+        };
 
         mClusterManager.setAlgorithm(mNodeAlgorithm);
         mClusterManager.setRenderer(mNodeRenderer);

--- a/app/src/main/java/com/dankideacentral/dic/activities/TweetFeedActivity.java
+++ b/app/src/main/java/com/dankideacentral/dic/activities/TweetFeedActivity.java
@@ -1,8 +1,5 @@
 package com.dankideacentral.dic.activities;
 
-import android.app.NotificationManager;
-import android.app.PendingIntent;
-import android.app.TaskStackBuilder;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -22,7 +19,6 @@ import android.support.v4.app.FragmentTransaction;
 
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.DrawerLayout;
-import android.support.v4.app.NotificationCompat;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
@@ -106,13 +102,9 @@ public class TweetFeedActivity extends BaseMapActivity
 
     public void initCurrentLocation() {
         Log.v(getClass().getName(), "initCurrentLocation");
-
         currentLocation = getIntent().getParcelableExtra(getString(
                 R.string.search_location_key));
-        // TODO: For demo, since unable to retrieve current loc, just redirect to Search
-        if (currentLocation == null) {
-            startActivity(new Intent(this, SearchActivity.class));
-        }
+
         // Case LatLng object returned is null (Could mean activity loaded on startup)
         if (currentLocation == null) {
             Log.v(getClass().getName(), "current loc was null");
@@ -172,11 +164,14 @@ public class TweetFeedActivity extends BaseMapActivity
                 String tweetUserName = tweet.getUser().getName();
                 long tweetUserId = tweet.getUser().getId();
                 if(friends.contains(tweetUserId)) {
-                    sendNotification("Your friend " + tweetUserName + " tweeted near you!");
+                    notificationHandler.sendNotification("Your friend " + tweetUserName + " tweeted near you!",
+                            notificationId++);
                 } else if(followers.contains(tweetUserId)) {
-                    sendNotification("Your follower " + tweetUserName + " tweeted near you!");
-                } else if(tweet.getUser().isVerified()) { // For testing purposes
-                    sendNotification("Celebrity Tweeter " + tweetUserName + " tweeted near you!");
+                    notificationHandler.sendNotification("Your follower " + tweetUserName + " tweeted near you!",
+                            notificationId++);
+                } else if(tweet.getUser().isVerified()) {
+                    notificationHandler.sendNotification("Celebrity Tweeter " + tweetUserName + " tweeted near you!",
+                            notificationId++);
                 }
             }
         }, new IntentFilter(getString(R.string.tweet_broadcast)));
@@ -184,88 +179,14 @@ public class TweetFeedActivity extends BaseMapActivity
         clusterManager = cm;
     }
 
-    private void sendNotification(String message) {
-        NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
-                        .setSmallIcon(R.drawable.ic_cloud_white_24dp)
-                        .setContentTitle("Migrate")
-                        .setContentText(message);
+    public void setToolbar(){
+        DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.activity_tweet_feed);
+        View navDrawer = setUpNavigationDrawer(drawerLayout);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar.getMenu().clear();
+        toolbar.setNavigationIcon(R.drawable.ic_nav_button);
 
-        // Creates an explicit intent for an Activity in your app
-        Intent resultIntent = new Intent(this, TweetFeedActivity.class);
-
-        // The stack builder object will contain an artificial back stack for the started Activity.
-        // This ensures that navigating backward from the Activity leads out of application to the
-        // Home screen.
-        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
-
-        // Adds the back stack for the Intent (but not the Intent itself)
-        stackBuilder.addParentStack(TweetFeedActivity.class);
-
-        // Adds the Intent that starts the Activity to the top of the stack
-        stackBuilder.addNextIntent(resultIntent);
-        PendingIntent resultPendingIntent =
-                stackBuilder.getPendingIntent(
-                        0,
-                        PendingIntent.FLAG_UPDATE_CURRENT
-                );
-        mBuilder.setContentIntent(resultPendingIntent);
-        NotificationManager mNotificationManager =
-                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-
-        // Give the notification a unique ID so that it can be updated later
-        mNotificationManager.notify(notificationId++, mBuilder.build());
-    }
-
-    /**
-     * Creates a new instance of a {@link LocationFinder} object,
-     * implementing its onLocationChanged() method to guarantee
-     * reception of current known location.
-     * <p>
-     * Once location is received, zooms the map fragment in to
-     * the received location.
-     */
-    private void getCurrentLocation(final Handler.Callback cb) {
-        final Context self = this;
-        locationFinder = new LocationFinder(this) {
-            @Override
-            protected void onError(int type) {
-                if (type == LocationFinder.LOCATION_SERVICES_OFF) {
-                    startActivity(new Intent(self, SearchActivity.class));
-                }
-            }
-
-            @Override
-            public void onLocationChanged(Location location) {
-                // Prevent further location updates from occurring
-                locationFinder.stopLocationUpdates();
-
-                // Disconnect from the googleApiClient
-                locationFinder.disconnect();
-                Message msg = new Message();
-                Bundle args = new Bundle();
-                args.putDouble("lat", location.getLatitude());
-                args.putDouble("lon", location.getLongitude());
-                msg.setData(args);
-                new Handler(cb).sendMessage(msg);
-            }
-        };
-    }
-
-    /**
-     * Starts the twitter stream service to receive
-     * tweets at the specified latitude & longitude locations.
-     *
-     * @param latLng
-     *          The {@link LatLng} location to open the service at.
-     */
-    private void startTwitterStreamService(LatLng latLng) {
-        // Start and bind TwitterStreamService
-        Intent startIntent = new Intent(this, TwitterStreamService.class);
-        // put the radius and location on the intent
-        startIntent.putExtra(getString(R.string.intent_lat), latLng.latitude);
-        startIntent.putExtra(getString(R.string.intent_long), latLng.longitude);
-        startService(startIntent);
+        setNavigationButtonListener(toolbar, drawerLayout, navDrawer);
     }
 
     @Override
@@ -321,19 +242,60 @@ public class TweetFeedActivity extends BaseMapActivity
         killService();
     }
 
+    /**
+     * Creates a new instance of a {@link LocationFinder} object,
+     * implementing its onLocationChanged() method to guarantee
+     * reception of current known location.
+     * <p>
+     * Once location is received, zooms the map fragment in to
+     * the received location.
+     */
+    private void getCurrentLocation(final Handler.Callback cb) {
+        final Context self = this;
+        locationFinder = new LocationFinder(this) {
+            @Override
+            protected void onError(int type) {
+                if (type == LocationFinder.LOCATION_SERVICES_OFF) {
+                    startActivity(new Intent(self, SearchActivity.class));
+                }
+            }
+
+            @Override
+            public void onLocationChanged(Location location) {
+                // Prevent further location updates from occurring
+                locationFinder.stopLocationUpdates();
+
+                // Disconnect from the googleApiClient
+                locationFinder.disconnect();
+                Message msg = new Message();
+                Bundle args = new Bundle();
+                args.putDouble("lat", location.getLatitude());
+                args.putDouble("lon", location.getLongitude());
+                msg.setData(args);
+                new Handler(cb).sendMessage(msg);
+            }
+        };
+    }
+
+    /**
+     * Starts the twitter stream service to receive
+     * tweets at the specified latitude & longitude locations.
+     *
+     * @param latLng
+     *          The {@link LatLng} location to open the service at.
+     */
+    private void startTwitterStreamService(LatLng latLng) {
+        // Start and bind TwitterStreamService
+        Intent startIntent = new Intent(this, TwitterStreamService.class);
+        // put the radius and location on the intent
+        startIntent.putExtra(getString(R.string.intent_lat), latLng.latitude);
+        startIntent.putExtra(getString(R.string.intent_long), latLng.longitude);
+        startService(startIntent);
+    }
+
     private void killService () {
         Intent stopServiceIntent = new Intent(this, TwitterStreamService.class);
         stopService(stopServiceIntent);
-    }
-
-    public boolean onOptionItemIsSelected(MenuItem item) {
-        // put code to handle actionbar items.. make sure you call super.onOptionItemSelected(item) as the default.
-
-        switch (item.getItemId()) {
-            default:
-                return false;
-        }
-
     }
 
     /**
@@ -569,16 +531,6 @@ public class TweetFeedActivity extends BaseMapActivity
             followers.addAll(followersSet);
         }
 
-    }
-
-    public void setToolbar(){
-        DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.activity_tweet_feed);
-        View navDrawer = setUpNavigationDrawer(drawerLayout);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.getMenu().clear();
-        toolbar.setNavigationIcon(R.drawable.ic_nav_button);
-
-        setNavigationButtonListener(toolbar, drawerLayout, navDrawer);
     }
 
 }

--- a/app/src/main/java/com/dankideacentral/dic/algo/WeightedNodeAlgorithm.java
+++ b/app/src/main/java/com/dankideacentral/dic/algo/WeightedNodeAlgorithm.java
@@ -3,7 +3,6 @@ package com.dankideacentral.dic.algo;
 import com.dankideacentral.dic.model.WeightedNode;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.Cluster;
-import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.clustering.algo.Algorithm;
 import com.google.maps.android.clustering.algo.StaticCluster;
 import com.google.maps.android.geometry.Bounds;
@@ -26,61 +25,6 @@ import java.util.Set;
 public class WeightedNodeAlgorithm <T extends WeightedNode> implements Algorithm <T> {
 
     public static final int MAX_DISTANCE_AT_ZOOM = 80; // essentially 100 dp.
-
-    private final Collection<WeightedItem<T>> mItems = new ArrayList<WeightedItem<T>>();
-
-    private final PointQuadTree<WeightedItem<T>> mWeightedTree = new PointQuadTree<WeightedItem<T>>(0, 1, 0, 1);
-
-    private static final SphericalMercatorProjection PROJECTION = new SphericalMercatorProjection(1);
-
-    private static class WeightedItem <T extends WeightedNode> implements PointQuadTree.Item, Cluster<T> {
-        private final T mClusterItem;
-        private final Point mPoint;
-        private final LatLng mPosition;
-        private Set<T> singletonSet;
-
-        private WeightedItem (T item) {
-            mClusterItem = item;
-            mPosition = item.getPosition();
-            mPoint = PROJECTION.toPoint(mPosition);
-            singletonSet = Collections.singleton(mClusterItem);
-        }
-
-        @Override
-        public Point getPoint() {
-            return mPoint;
-        }
-
-        @Override
-        public LatLng getPosition() {
-            return mPosition;
-        }
-
-        @Override
-        public Set<T> getItems() {
-            return singletonSet;
-        }
-
-        @Override
-        public int getSize() {
-            return mClusterItem.getSize();
-        }
-
-        @Override
-        public int hashCode() {
-            return mClusterItem.hashCode();
-        };
-
-        @Override
-        public boolean equals(Object other) {
-            if (!(other instanceof WeightedItem<?>)) {
-                return false;
-            }
-
-            return ((WeightedItem<?>) other).mClusterItem.equals(mClusterItem);
-        }
-    }
-
 
     @Override
     public void addItem(T item) {
@@ -165,6 +109,17 @@ public class WeightedNodeAlgorithm <T extends WeightedNode> implements Algorithm
         return results;
     }
 
+    @Override
+    public Collection<T> getItems() {
+        return null;
+    }
+
+    private final Collection<WeightedItem<T>> mItems = new ArrayList<WeightedItem<T>>();
+
+    private final PointQuadTree<WeightedItem<T>> mWeightedTree = new PointQuadTree<WeightedItem<T>>(0, 1, 0, 1);
+
+    private static final SphericalMercatorProjection PROJECTION = new SphericalMercatorProjection(1);
+
     private Bounds createBoundsFromSpan(Point p, double span) {
         // TODO: Use a span that takes into account the visual size of the marker, not just its
         // LatLng.
@@ -176,8 +131,52 @@ public class WeightedNodeAlgorithm <T extends WeightedNode> implements Algorithm
     private double distanceSquared(Point a, Point b) {
         return (a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y);
     }
-    @Override
-    public Collection<T> getItems() {
-        return null;
+
+    private static class WeightedItem <T extends WeightedNode> implements PointQuadTree.Item, Cluster<T> {
+        private final T mClusterItem;
+        private final Point mPoint;
+        private final LatLng mPosition;
+        private Set<T> singletonSet;
+
+        private WeightedItem (T item) {
+            mClusterItem = item;
+            mPosition = item.getPosition();
+            mPoint = PROJECTION.toPoint(mPosition);
+            singletonSet = Collections.singleton(mClusterItem);
+        }
+
+        @Override
+        public Point getPoint() {
+            return mPoint;
+        }
+
+        @Override
+        public LatLng getPosition() {
+            return mPosition;
+        }
+
+        @Override
+        public Set<T> getItems() {
+            return singletonSet;
+        }
+
+        @Override
+        public int getSize() {
+            return mClusterItem.getSize();
+        }
+
+        @Override
+        public int hashCode() {
+            return mClusterItem.hashCode();
+        };
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof WeightedItem<?>)) {
+                return false;
+            }
+
+            return ((WeightedItem<?>) other).mClusterItem.equals(mClusterItem);
+        }
     }
 }

--- a/app/src/main/java/com/dankideacentral/dic/util/NotificationHandler.java
+++ b/app/src/main/java/com/dankideacentral/dic/util/NotificationHandler.java
@@ -1,0 +1,82 @@
+package com.dankideacentral.dic.util;
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.TaskStackBuilder;
+
+import com.dankideacentral.dic.R;
+
+/**
+ * Class:   NotificationHandler.java
+ * Purpose: Util to send application push
+ *          notifications.
+ *
+ * @author Chris Ermel & Basim Ramadhan
+ * @version 1.0
+ * @since 2016-11-20
+ */
+public class NotificationHandler {
+
+    private NotificationCompat.Builder notificationBuilder;
+    private TaskStackBuilder taskStackBuilder;
+    private NotificationManager notificationManager;
+
+    public NotificationHandler(final Context context, final Class activity) {
+        notificationBuilder = new NotificationCompat.Builder(context)
+                .setSmallIcon(R.drawable.ic_cloud_white_24dp)
+                .setContentTitle(context.getString(R.string.app_name));
+        notificationManager = (NotificationManager) context.getSystemService(
+                Context.NOTIFICATION_SERVICE);
+
+        taskStackBuilder = TaskStackBuilder.create(context);
+        setNotificationRedirectIntent(context, activity);
+    }
+
+    /**
+     * Sends a notification to Android.
+     *
+     * @param message
+     *          The string message that will appear
+     *          in the notification.
+     *
+     * @param notificationId
+     *          The identification number of the
+     *          notification, for notification updating.
+     */
+    public void sendNotification(final String message, final int notificationId) {
+        // Sets the notifications message
+        notificationBuilder.setContentText(message);
+
+        // Give the notification a unique ID so that it can be updated later
+        notificationManager.notify(notificationId, notificationBuilder.build());
+    }
+
+    /**
+     * Sets the intent/activity the notification will load
+     * when clicked by the user.
+     *
+     * @param context
+     *          The context from which the intent is
+     *          being created.
+     *
+     * @param activity
+     *          The activity to open on notification click.
+     */
+    public void setNotificationRedirectIntent(final Context context, final Class activity) {
+        // Create concrete intent for notification to redirect to
+        Intent redirectIntent = new Intent(context, activity);
+
+        // Adds the back stack for the Intent (but not the Intent itself)
+        taskStackBuilder.addParentStack(activity);
+
+        // Adds the Intent that starts the Activity to the top of the stack
+        taskStackBuilder.addNextIntent(redirectIntent);
+
+        // Set the notification builder's pending intent
+        notificationBuilder.setContentIntent(
+                taskStackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT));
+    }
+}

--- a/app/src/main/java/com/dankideacentral/dic/view/WeightedNodeRenderer.java
+++ b/app/src/main/java/com/dankideacentral/dic/view/WeightedNodeRenderer.java
@@ -55,20 +55,24 @@ import static com.google.maps.android.clustering.algo.NonHierarchicalDistanceBas
 /**
  * The default view for a ClusterManager. Markers are animated in and out of clusters.
  */
-public class WeightedNodeRenderer<T extends ClusterItem> implements ClusterRenderer<T> {
+public abstract class WeightedNodeRenderer<T extends ClusterItem> implements ClusterRenderer<T> {
     private static final String TAG = "WeightedNodeRenderer";
     private static final boolean SHOULD_ANIMATE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
     private final GoogleMap mMap;
     private final ClusterManager<T> mClusterManager;
     private final float mDensity;
 
+    /**
+     * Sends a notification to the user.
+     * Abstract as algorithm is not concerned with how this is done.
+     */
+    public abstract void sendUserNotification();
 
     /**
      * Markers that are currently on the map.
      */
     private Set<MarkerWithPosition> mMarkers = Collections.newSetFromMap(
             new ConcurrentHashMap<MarkerWithPosition, Boolean>());
-
 
     /**
      * Markers for single ClusterItems.
@@ -812,6 +816,7 @@ public class WeightedNodeRenderer<T extends ClusterItem> implements ClusterRende
                     onClusterRendered(cluster, marker);
 
                     newMarkers.add(markerWithPosition);
+                    sendUserNotification();
                 }
             }.execute(markerOptions);
         }


### PR DESCRIPTION
### Description
Moved notification pushing logic to its own class and added a notification that occurs on clustering.
Notification for the event clustering uses the same ID to update the same notification.

### Changelog
- Factor out notification logic from TweetFeedActivity
- Add event notification to WeightedNodeRenderer
- misc reordering of public/protected/private methods in certain edited classes

### Addresses Issues
#100 
